### PR TITLE
Add and show error descriptions

### DIFF
--- a/Taurine/app/ViewController.swift
+++ b/Taurine/app/ViewController.swift
@@ -286,7 +286,7 @@ class ViewController: UIViewController, ElectraUI {
                 DispatchQueue.main.async {
                     self.jailbreakButton.setProgress(1.0, animated: true)
                     if err != .ERR_NOERR {
-                        self.showAlert("Oh no", "\(String(describing: err))", sync: false, callback: {
+                        self.showAlert("Error occured", err.description, sync: false, callback: {
                             UIApplication.shared.beginBackgroundTask {
                                 print("odd. this should never be called.")
                             }

--- a/Taurine/post-exploit/electra.swift
+++ b/Taurine/post-exploit/electra.swift
@@ -8,9 +8,8 @@
 
 import Foundation
 
-enum JAILBREAK_RETURN_STATUS {
+enum JAILBREAK_RETURN_STATUS: CustomStringConvertible {
     case ERR_NOERR
-    case ERR_VERSION
     case ERR_EXPLOIT
     case ERR_UNSUPPORED
     case ERR_KERNRW
@@ -20,6 +19,31 @@ enum JAILBREAK_RETURN_STATUS {
     case ERR_SNAPSHOT
     case ERR_JAILBREAK
     case ERR_CONFLICT
+    
+    var description: String {
+        switch self {
+        case .ERR_NOERR:
+            return "No error encountered"
+        case .ERR_EXPLOIT:
+            return "Exploit failed - reboot and try again!"
+        case .ERR_UNSUPPORED:
+            return "Device or version unsupported"
+        case .ERR_KERNRW:
+            return "Explpot failed - reboot and try again"
+        case .ERR_ALREADY_JAILBROKEN:
+            return "Jailbreak Process was interrupted - Please reboot and try again!"
+        case .ERR_ROOTFS_RESTORE:
+            return "Error occured while trying to restore-rootfs, reboot and try again!"
+        case .ERR_REMOUNT:
+            return "Error occured while re-mounting /"
+        case .ERR_SNAPSHOT:
+            return "Error occured while creating snapshot of root filesystem"
+        case .ERR_JAILBREAK:
+            return "Unknown error has occured while trying to jailbreak"
+        case .ERR_CONFLICT:
+            return "Conflict error occured - please restore rootfs first then try to jailbreak."
+        }
+    }
 }
 
 protocol ElectraUI {


### PR DESCRIPTION
This pull request adds and shows descriptions to errors in `JAILBREAK_RETURN_STATUS`, and also removes an unused error case