### PR TITLE
(probably not the most mergable) *reliable* M1 iPad Pro support

### DIFF
--- a/Taurine/app/ViewController.swift
+++ b/Taurine/app/ViewController.swift
@@ -262,7 +262,7 @@ class ViewController: UIViewController, ElectraUI {
                 case .kfdPhysPuppet:
                     print("Selecting kfd [physpuppet] for iOS 14.0 - 14.8.1")
                     LogStream.shared.pause()
-                    let ret = do_kopen(0x800, 0x0, 0x2, 0x2)
+                    let ret = do_kopen(0x20000, 0x0, 0x2, 0x2)
                     LogStream.shared.resume()
                     if ret != 0 {
                         print("Successfully exploited kernel!");
@@ -272,7 +272,7 @@ class ViewController: UIViewController, ElectraUI {
                 case .kfdSmith:
                     print("Selecting kfd [smith] for iOS 14.0 - 14.8.1")
                     LogStream.shared.pause()
-                    let ret = do_kopen(0x800, 0x1, 0x2, 0x2)
+                    let ret = do_kopen(0x20000, 0x1, 0x2, 0x2)
                     LogStream.shared.resume()
                     if ret != 0 {
                         print("Successfully exploited kernel!");

--- a/Taurine/exploit/kfd/libkfd.h
+++ b/Taurine/exploit/kfd/libkfd.h
@@ -176,7 +176,7 @@ u64 kopen(u64 puaf_pages, u64 puaf_method, u64 kread_method, u64 kwrite_method)
     timer_start();
 
     const u64 puaf_pages_min = 16;
-    const u64 puaf_pages_max = 2048;
+    const u64 puaf_pages_max = 131072;
     assert(puaf_pages >= puaf_pages_min);
     assert(puaf_pages <= puaf_pages_max);
     assert(puaf_method <= puaf_smith);

--- a/Taurine/exploit/kfd/libkfd/krkw.h
+++ b/Taurine/exploit/kfd/libkfd/krkw.h
@@ -208,6 +208,10 @@ loop_break:
         for (u64 i = 0; i < kfd->puaf.number_of_puaf_pages; i++) {
             u64 puaf_page_uaddr = kfd->puaf.puaf_pages_uaddr[i];
             print_buffer(puaf_page_uaddr, 64);
+            
+            uint32_t magicToSearch = 0x1EA5CACE;
+            void *res = memmem((void *)kfd->puaf.puaf_pages_uaddr[i], 0x4000, &magicToSearch, sizeof(magicToSearch));
+            assert(res == NULL);
         }
 
         assert_false(krkw_type);

--- a/Taurine/exploit/kfd/libkfd/krkw/kread/kread_IOSurface.h
+++ b/Taurine/exploit/kfd/libkfd/krkw/kread/kread_IOSurface.h
@@ -25,7 +25,7 @@ u32 kread_IOSurface_kread_u32(struct kfd* kfd, u64 kaddr);
 
 void kread_IOSurface_init(struct kfd* kfd)
 {
-    kfd->kread.krkw_maximum_id = 0x4000;
+    kfd->kread.krkw_maximum_id = 0x1000;
     kfd->kread.krkw_object_size = 0x400; //estimate
 
     kfd->kread.krkw_method_data_size = ((kfd->kread.krkw_maximum_id) * (sizeof(struct iosurface_obj)));

--- a/Taurine/post-exploit/cutils.h
+++ b/Taurine/post-exploit/cutils.h
@@ -36,8 +36,8 @@ void setLr(arm_thread_state64_t *state, uint64_t lr);
 void setPc(arm_thread_state64_t *state, uint64_t pc);
 void amfid_test(mach_port_t amfid_port);
 
-#ifdef ENABLE_XPC
-#include <xpc/xpc.h>
+ #ifdef ENABLE_XPC
+ #include <xpc/xpc.h>
 // os_alloc_once_table:
 //
 // Ripped this from XNU's libsystem

--- a/Taurine/post-exploit/utils/amfidtakeover.swift
+++ b/Taurine/post-exploit/utils/amfidtakeover.swift
@@ -245,7 +245,7 @@ class AmfidTakeover {
                 }
                 
                 let req = head.withMemoryRebound(to: exception_raise_request.self,
-                                                 capacity: 0x4000) { $0.pointee }
+                                                 capacity: 1) { $0.pointee }
                 
                 let thread_port = req.thread.name
                 let task_port = req.task.name


### PR DESCRIPTION
I honestly doubt that this is mergable for two main reasons:
- The fixes being made cause us to use over 4GB of RAM, which pretty much every device besides the M1 iPad Pro's will not be happy with whatsoever
- The fixes being made, even ignoring that bit, cause exploitation time to balloon to over 3 minutes with kfd (which no other device should suffer through)

Thanks @opa334 and @verygenericname for various fixes in helping me to make this a thing.